### PR TITLE
Fix Cookie

### DIFF
--- a/_includes/cookies.html
+++ b/_includes/cookies.html
@@ -15,8 +15,7 @@
   const manageCookiesButton = document.getElementById('manage-cookies');
 
   acceptCookiesButton.addEventListener('click', () => {
-    allowFacebookPixel(true);
-    allowGoogleAnalytics(true);
+    setAnalyticsSettings(true, true);
     hide(disclaimer);
   });
 
@@ -24,7 +23,7 @@
     window.location.href = '{{ site.baseurl }}/cookie-policy'
   });
 
-  if (!hasConsentSettings()) {
+  if (!getCookieSettings().confirmed) {
     setTimeout(() => show(disclaimer), 5000);
   }
 </script>

--- a/assets/js/cookies.js
+++ b/assets/js/cookies.js
@@ -23,7 +23,7 @@ function itob(i) {
 }
 
 function getCookieSettings() {
-  const settings = Cookies.get(CONSENT_COOKIE, COOKIE_OPTIONS)
+  const settings = Cookies.get(CONSENT_COOKIE);
   if (!settings) {
     return new CookieSettings(false, false, false);
   }

--- a/cookie-policy.md
+++ b/cookie-policy.md
@@ -35,12 +35,14 @@ SteffWedding.com използва бисквитки за да разбере к
   const fbpCookiesButton = document.getElementById('manage-fbp-cookies');
   const saveCookiesButton = document.getElementById('save-cookies');
 
-  gaCookiesButton.dataset.active = isGoogleAnalyticsAllowed() ? 't' : 'f';
-  fbpCookiesButton.dataset.active = isFacebookPixelAllowed() ? 't' : 'f';
+  const settings = getCookieSettings();
+  gaCookiesButton.dataset.active = settings.gtag ? 't' : 'f';
+  fbpCookiesButton.dataset.active = settings.fbp ? 't' : 'f';
 
   saveCookiesButton.addEventListener('click', () => {
-    allowFacebookPixel(fbpCookiesButton.dataset.active === 't');
-    allowGoogleAnalytics(gaCookiesButton.dataset.active === 't');
-    applyConsentSettings();
+    setAnalyticsSettings(
+      fbpCookiesButton.dataset.active === 't',
+      gaCookiesButton.dataset.active === 't'
+    );
   });
 </script>


### PR DESCRIPTION
fixes #15
* The JS cookie library was probably updated and the existing logic no longer worked. To make changes forward compatible, the cookie now contains a version and a bunch of booleans compacted as numbers separated with `:`. The functions are still able to parse the old cookie format.
* The SameSite attribute is now set to `Strict` 
