### PR TITLE
[Fixes #5] Less Rows In Dress Sticky Info

### DIFF
--- a/_layouts/dress.html
+++ b/_layouts/dress.html
@@ -8,23 +8,23 @@ title: Рокли
 <div class="dress container">
   <article id="dress-text" class="dress text">
     {{ page.sw-dress-description | newline_to_br }}
+    <p class="text center">
+      <b>Колекция</b><br />
+      <a class="link" href="{{ collection.url }}">{{ collection.sw-collection-name }}</a>
+    </p>
+    {% if page.sw-dress-designer %}
+    <p class="text center">
+      <b>Дизайнер</b><br />
+      {{ page.sw-dress-designer }}
+    </p>
+    {% endif %}
+    {% if page.sw-dress-producer %}
+    <p class="text center">
+      <b>Производител</b><br />
+      {{ page.sw-dress-producer }}
+    </p>
+    {% endif %}
     <div class="dress details">
-      <p class="text center">
-        <b>Колекция</b><br />
-        <a class="link" href="{{ collection.url }}">{{ collection.sw-collection-name }}</a>
-      </p>
-      {% if page.sw-dress-designer %}
-      <p class="text center">
-        <b>Дизайнер</b><br />
-        {{ page.sw-dress-designer }}
-      </p>
-      {% endif %}
-      {% if page.sw-dress-producer %}
-      <p class="text center">
-        <b>Производител</b><br />
-        {{ page.sw-dress-producer }}
-      </p>
-      {% endif %}
       <p class="text center">
         <b>Размери</b><br />
         {{ page.sw-dress-sizes }}


### PR DESCRIPTION
On smaller screens, the lines are too many and crucial information becomes invisible. Correct the size of the sticky portion of the text, so that the most important items are always visible, even on smaller screens.